### PR TITLE
Add `files` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "node tests.js"
   },
+  "files": [
+    "lib/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/S2-/securerandomstring.git"


### PR DESCRIPTION
This way, users who install this module don't have to download irrelevant stuff like the test file.
